### PR TITLE
BUGFIX: Could not find member 'expiresOn' on object of type 'Auth'. Path 'expiresOn

### DIFF
--- a/UltimateTeam.Toolkit/Models/Auth.cs
+++ b/UltimateTeam.Toolkit/Models/Auth.cs
@@ -11,5 +11,7 @@
         public string ServerTime { get; set; }
 
         public string Sid { get; set; }
+		
+		public string ExpiresOn { get; set; }
     }
 }


### PR DESCRIPTION
Could not find member 'expiresOn' on object of type 'Auth'. Path 'expiresOn
