### PR TITLE
Add method to retrieve consumable details for consumables in your club

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ FIFA Ultimate Team Toolkit
 [Get & Solve Captcha](https://github.com/trydis/FIFA-Ultimate-Team-Toolkit#get-solve-captcha)  
 [Remove sold items from trade pile](https://github.com/trydis/FIFA-Ultimate-Team-Toolkit#remove-sold-items-from-trade-pile)  
 [Open a pack](https://github.com/trydis/FIFA-Ultimate-Team-Toolkit#open-a-pack)  
+[Get club consumables details](https://github.com/trydis/FIFA-Ultimate-Team-Toolkit#get-club-consumables-details)
 
 ### Initialization
 
@@ -388,3 +389,15 @@ foreach (var packDetail in storeResponse.Purchase)
 var buyPackResponse = await futClient.BuyPackAsync(new PackDetails(packId));
 ```
 
+### Get club consumables details
+
+Get details about the consumables you have in your club, especially the counts.
+
+```csharp
+var consumablesDetailsResponse = await futClient.GetConsumablesDetailsAsync();
+foreach (var consumablesDetail in consumablesDetailsResponse.ItemData)
+{
+    consumablesDetail.ResourceId // resource id of the consumable
+    consumablesDetail.Count; // count
+}
+```

--- a/UltimateTeam.Toolkit/Constants/Resources.cs
+++ b/UltimateTeam.Toolkit/Constants/Resources.cs
@@ -80,6 +80,8 @@ namespace UltimateTeam.Toolkit.Constants
 
         public const string Consumables = "club/stats/consumables";
 
+        public const string ConsumablesDetails = "club/consumables/development";
+
         public const string SquadList = "squad/list";
 
         public const string SquadDetails = "squad/{0}";

--- a/UltimateTeam.Toolkit/Factories/FutRequestFactories.cs
+++ b/UltimateTeam.Toolkit/Factories/FutRequestFactories.cs
@@ -76,6 +76,8 @@ namespace UltimateTeam.Toolkit.Factories
 
         private Func<IFutRequest<ConsumablesResponse>> _consumablesRequestFactory;
 
+        private Func<IFutRequest<ConsumablesDetailsResponse>> _consumablesDetailsRequestFactory;
+
         private Func<IFutRequest<RelistResponse>> _reListRequestFactory;
 
         private Func<IFutRequest<ListGiftsResponse>> _giftListRequestFactory;
@@ -552,6 +554,21 @@ namespace UltimateTeam.Toolkit.Factories
                 _consumablesRequestFactory = value;
             }
         }
+
+        public Func<IFutRequest<ConsumablesDetailsResponse>> ConsumablesDetailsRequestFactory
+        {
+            get
+            {
+                return _consumablesDetailsRequestFactory ??
+                       (_consumablesDetailsRequestFactory = () => SetSharedRequestProperties(new ConsumablesDetailsRequest()));
+            }
+            set
+            {
+                value.ThrowIfNullArgument();
+                _consumablesDetailsRequestFactory = value;
+            }
+        }
+
         public Func<long, IFutRequest<DefinitionResponse>> DefinitionRequestFactory
         {
             get

--- a/UltimateTeam.Toolkit/FutClient.cs
+++ b/UltimateTeam.Toolkit/FutClient.cs
@@ -101,6 +101,11 @@ namespace UltimateTeam.Toolkit
             return RequestFactories.ConsumablesRequestFactory().PerformRequestAsync();
         }
 
+        public Task<ConsumablesDetailsResponse> GetConsumablesDetailsAsync()
+        {
+            return RequestFactories.ConsumablesDetailsRequestFactory().PerformRequestAsync();
+        }
+
         public Task<AuctionResponse> GetTradePileAsync()
         {
             return RequestFactories.TradePileRequestFactory().PerformRequestAsync();

--- a/UltimateTeam.Toolkit/IFutClient.cs
+++ b/UltimateTeam.Toolkit/IFutClient.cs
@@ -63,6 +63,8 @@ namespace UltimateTeam.Toolkit
 
         Task<ConsumablesResponse> GetConsumablesAsync();
 
+        Task<ConsumablesDetailsResponse> GetConsumablesDetailsAsync();
+
         Task<byte[]> GetClubImageAsync(AuctionInfo auctionInfo);
 
         Task<byte[]> GetNationImageAsync(Item item);

--- a/UltimateTeam.Toolkit/Models/ConsumablesDetails.cs
+++ b/UltimateTeam.Toolkit/Models/ConsumablesDetails.cs
@@ -1,0 +1,15 @@
+using System.Collections.Generic;
+
+namespace UltimateTeam.Toolkit.Models
+{
+    public class ConsumablesDetails
+    {
+        public uint Count { get; set; }
+
+        public ushort? DiscardValue { get; set; }
+
+        public long ResourceId { get; set; }
+
+        public uint UntradeableCount { get; set; }
+    }
+}

--- a/UltimateTeam.Toolkit/Models/ConsumablesDetailsResponse.cs
+++ b/UltimateTeam.Toolkit/Models/ConsumablesDetailsResponse.cs
@@ -1,0 +1,9 @@
+using System.Collections.Generic;
+
+namespace UltimateTeam.Toolkit.Models
+{
+    public class ConsumablesDetailsResponse
+    {
+        public List<ConsumablesDetails> ItemData { get; set; }
+    }
+}

--- a/UltimateTeam.Toolkit/Requests/ConsumablesDetailsRequest.cs
+++ b/UltimateTeam.Toolkit/Requests/ConsumablesDetailsRequest.cs
@@ -1,0 +1,33 @@
+﻿using System;
+using System.Net.Http;
+using System.Threading.Tasks;
+using UltimateTeam.Toolkit.Constants;
+using UltimateTeam.Toolkit.Extensions;
+using UltimateTeam.Toolkit.Models;
+
+namespace UltimateTeam.Toolkit.Requests
+{
+    internal class ConsumablesDetailsRequest : FutRequestBase, IFutRequest<ConsumablesDetailsResponse>
+    {
+        public async Task<ConsumablesDetailsResponse> PerformRequestAsync()
+        {
+            var uriString = Resources.FutHome + Resources.ConsumablesDetails;
+
+            if (AppVersion == AppVersion.WebApp)
+            {
+                AddCommonHeaders(HttpMethod.Get);
+            }
+            else
+            {
+                AddCommonMobileHeaders();
+                uriString += $"?_={DateTime.Now.ToUnixTime()}";
+            }
+
+            var consumablesDetailsResponseMessage = await HttpClient
+                .GetAsync(string.Format(uriString))
+                .ConfigureAwait(false);
+
+            return await DeserializeAsync<ConsumablesDetailsResponse>(consumablesDetailsResponseMessage);
+        }
+    }
+}

--- a/UltimateTeam.Toolkit/UltimateTeam.Toolkit.csproj
+++ b/UltimateTeam.Toolkit/UltimateTeam.Toolkit.csproj
@@ -86,6 +86,8 @@
     <Compile Include="FutClient.cs" />
     <Compile Include="IFutClient.cs" />
     <Compile Include="Models\Attribute.cs" />
+    <Compile Include="Models\ConsumablesDetails.cs" />
+    <Compile Include="Models\ConsumablesDetailsResponse.cs" />
     <Compile Include="Models\PackDetails.cs" />
     <Compile Include="Models\PackContentInfo.cs" />
     <Compile Include="Models\PackExtPrice.cs" />
@@ -181,6 +183,7 @@
     <Compile Include="Requests\AddToWatchlistRequest.cs" />
     <Compile Include="Requests\CaptchaRequest.cs" />
     <Compile Include="Requests\ClubImageRequest.cs" />
+    <Compile Include="Requests\ConsumablesDetailsRequest.cs" />
     <Compile Include="Requests\ConsumablesRequest.cs" />
     <Compile Include="Requests\ClubItemRequest.cs" />
     <Compile Include="Requests\DefinitionRequest.cs" />


### PR DESCRIPTION
I had the need to check how much of a specific contract type are in my club, so that I know how much I can add to the trade pile. The current toolkit doesn't have a method to get that information, so I added a method that does it for all types of consumables.